### PR TITLE
feat: create first user when seed and allow token bearer in swagger

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,3 +5,8 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="postgresql://carbonable:carbonable@localhost:5432/carbonable_ccpm"
+JWT_KEY="189c982c0554bcb313390dc4b233faefa073696900dc7d85122c9b37cf4cc4ce"
+DEFAULT_ADMIN_NAME="admin" 
+DEFAULT_ADMIN_PASSWORD="changeme"
+DEFAULT_ADMIN_ROLES=['user','admin']
+CARBONABLE_SALT=78860

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 DATABASE_URL="postgresql://test:test@localhost:5432/carbonable_ccpm_test"
 JWT_KEY="189c982c0554bcb313390dc4b233faefa073696900dc7d85122c9b37cf4cc4ce"
+CARBONABLE_SALT=78860
 
 # For testing purpose only.Never use a .env file for that critical information
 DEFAULT_ADMIN_NAME="admin" 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:e1e": "jest --config ./test/jest-e2e.json --detectOpenHandles",
     "fixtures": "ts-node src/fixtures/index.ts",
     "db:reset": "prisma db push --force-reset && prisma db seed && pnpm console fixtures",
+    "db:init": "prisma db push --force-reset && prisma db seed",
     "test:integration:suite": "just test_integration",
     "test:db:reset": "dotenv -e .env.test -- pnpm db:reset",
     "prepare": "husky install"

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,11 +1,29 @@
 /// <reference lib="dom" />
 import { PrismaClient } from '@prisma/client';
 import { monotonicFactory } from 'ulid';
+import * as bcrypt from 'bcrypt';
 
 const prisma = new PrismaClient();
 const ulid = monotonicFactory();
 
 async function seed() {
+  try {
+    await seedCountries();
+    await seedUsers();
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+seed()
+  .catch(async (e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => await prisma.$disconnect());
+
+async function seedCountries() {
   const countries = await getCountries();
   for (const country of countries) {
     await prisma.country.create({
@@ -19,12 +37,40 @@ async function seed() {
   }
 }
 
-seed()
-  .catch(async (e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => await prisma.$disconnect());
+async function seedUsers() {
+  const data = await getAdmin();
+  await prisma.user.create({
+    data,
+  });
+}
+
+async function getAdmin(): Promise<any> {
+  const name = process.env.DEFAULT_ADMIN_NAME;
+  const password = process.env.DEFAULT_ADMIN_PASSWORD;
+  const rolesEnv = process.env.DEFAULT_ADMIN_ROLES;
+
+  if (!rolesEnv || !name || !password) {
+    throw new Error(
+      'DEFAULT_ADMIN_NAME, DEFAULT_ADMIN_PASSWORD, or DEFAULT_ADMIN_ROLES are not defined in the environment variables',
+    );
+  }
+
+  const adminExists = await prisma.user.findFirst({
+    where: { roles: { has: 'admin' } },
+  });
+
+  if (!adminExists) {
+    const roles = rolesEnv.replace(/[\[\]']/g, '').split(',');
+    const CARBONABLE_SALT = parseInt(process.env.CARBONABLE_SALT);
+    const hashedPassword = await bcrypt.hash(password, CARBONABLE_SALT);
+    return {
+      id: ulid().toString(),
+      name,
+      password: hashedPassword,
+      roles,
+    };
+  }
+}
 
 async function getCountries(): Promise<any[]> {
   const res = await fetch(

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -4,7 +4,6 @@
 // import * as request from 'supertest';
 // import { Role } from '../roles/role.enum';
 // import * as bcrypt from 'bcrypt';
-// import { CARBONABLE_SALT } from '../auth/constants';
 // import { INestApplication } from '@nestjs/common';
 // import { AppModule } from '../app.module';
 // import { ValidationPipe } from '@nestjs/common';
@@ -15,6 +14,7 @@ describe('AuthController (e2e)', () => {
   // let prismaService: PrismaService;
   // let adminToken: string;
   // let userToken: string;
+  // const CARBONABLE_SALT = parseInt(process.env.CARBONABLE_SALT);
   // beforeAll(async () => {
   //   const moduleFixture: TestingModule = await Test.createTestingModule({
   //     imports: [AppModule],

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -2,5 +2,3 @@ export const jwtConstants = {
   secret: process.env.JWT_KEY,
   duration: '1h',
 };
-
-export const CARBONABLE_SALT = 78860;

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ async function bootstrap() {
     .setDescription('The carbonable CCPM API description')
     .setVersion('1.0')
     .addTag('CCPM')
+    .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, ConflictException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
-import { CARBONABLE_SALT } from '../auth/constants';
 import { PrismaService } from '../infrastructure/prisma.service';
 import { Role } from '../roles/role.enum';
 import { Logger } from '@nestjs/common';
@@ -33,6 +32,8 @@ export class UsersService {
     if (existingUser) {
       throw new ConflictException('Username already exists');
     }
+
+    const CARBONABLE_SALT = parseInt(process.env.CARBONABLE_SALT);
     const hashedPassword = await bcrypt.hash(password, CARBONABLE_SALT);
     const userCreated = await this.prisma.user.create({
       data: {


### PR DESCRIPTION
Enabling first admin creation when seeding the database without having to load test fixtures.

In the full end to end process, we will update the user model and add more apis to ensure that the user must change its password when first login. To be done later.